### PR TITLE
fix(response): prevent app from crashing on second message

### DIFF
--- a/fastapi_async_langchain/response.py
+++ b/fastapi_async_langchain/response.py
@@ -63,5 +63,6 @@ class LangchainStreamingResponse(StreamingResponse):
                     "more_body": False,
                 }
             )
+            return
 
         await send({"type": "http.response.body", "body": b"", "more_body": False})

--- a/fastapi_async_langchain/response.py
+++ b/fastapi_async_langchain/response.py
@@ -25,6 +25,10 @@ class LangchainStreamingResponse(StreamingResponse):
                     raise TypeError(
                         "llm.callback_manager must be an instance of AsyncCallbackManager"
                     )
+                for handler in chain.llm.callback_manager.handlers:
+                    if isinstance(handler, AsyncFastApiStreamingCallback):
+                        chain.llm.callback_manager.remove_handler(handler)
+                        break
                 chain.llm.callback_manager.add_handler(
                     AsyncFastApiStreamingCallback(send=send)
                 )


### PR DESCRIPTION
## Description

Fixes #3

### Changelog

- 🐛 fix LLM callback handlers
- 🐛 fix error handling inside `LangchainStreamingResponse`