### PR TITLE
feat: add support to run background task with chain output

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -41,7 +41,7 @@ conversation_chain = conversation_chain_dependency()
 async def chat(
     request: Request,
     chain: ConversationChain = Depends(conversation_chain),
-):
+) -> LangchainStreamingResponse:
     return LangchainStreamingResponse(
         chain, request.query, media_type="text/event-stream"
     )


### PR DESCRIPTION
## Description

This PR adds support to run a background task with the LLM chain output. This is useful for any after-response operations such as updating a database, running additional code conditioned on chain output, etc.

### Changelog

- ⚡ updated `LangchainStreamingResponse` to convert `background` attribute into a partial if `chain.arun` is successful