### PR TITLE
fix(response): pass `BaseLangchainStreamingResponse` exception output to background task as `"outputs"`

### DIFF
--- a/fastapi_async_langchain/responses/base.py
+++ b/fastapi_async_langchain/responses/base.py
@@ -44,6 +44,8 @@ class BaseLangchainStreamingResponse(StreamingResponse):
             if self.background is not None:
                 self.background.kwargs["outputs"] = outputs
         except Exception as e:
+            if self.background is not None:
+                self.background.kwargs["outputs"] = str(e)
             await send(
                 {
                     "type": "http.response.body",


### PR DESCRIPTION
## Description

Fixes #27 

### Changelog:

- 🐛 fixed error handling in `BaseLangchainStreamingResponse`
