### PR TITLE
Fix Gradio Streaming problems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,5 @@ poetry install
 fastapi-async-langchain uses `pre-commit` to run code checks and tests before every commit. To install the pre-commit hooks, run the following commands:
 
 ```bash
-pip install pre-commit
 pre-commit install
 ```

--- a/fastapi_async_langchain/testing/gradio.py
+++ b/fastapi_async_langchain/testing/gradio.py
@@ -12,12 +12,32 @@ def send_query(api_url: str, query: str, chat: list[Any], history: list[Any]):
     history.append(query)
 
     payload = {"query": query}
-    headers = {"accept": "text/event-stream", "Content-Type": "application/json"}
-    response = requests.post(api_url, headers=headers, json=payload, stream=True)
+    headers = {
+        "accept": "text/event-stream", 
+        "Content-Type": "application/json",
+        "Connection": "keep-alive"
+    }
+    
+    try:
+        response = requests.post(api_url, headers=headers, json=payload, timeout=60, stream=True)
+        response.raise_for_status()  # Raise stored HTTPError, if one occurred
+
+    except requests.exceptions.HTTPError as httpErr:
+        print(f"HTTP error occurred: {httpErr}")
+        return
+    except requests.exceptions.ConnectionError as connErr:
+        print(f"Error connecting: {connErr}")
+        return
+    except requests.exceptions.Timeout as timeOutErr:
+        print(f"Timeout error: {timeOutErr}")
+        return
+    except requests.exceptions.RequestException as reqErr:
+        print(f"Something went wrong with the request: {reqErr}")
+        return
 
     token_counter = 0
     partial_words = ""
-    for chunk in response.iter_content():
+    for chunk in response.iter_content(chunk_size=1024):  # Smaller chunk size
         if chunk:
             partial_words = partial_words + chunk.decode()
             if token_counter == 0:

--- a/fastapi_async_langchain/testing/gradio.py
+++ b/fastapi_async_langchain/testing/gradio.py
@@ -13,13 +13,15 @@ def send_query(api_url: str, query: str, chat: list[Any], history: list[Any]):
 
     payload = {"query": query}
     headers = {
-        "accept": "text/event-stream", 
+        "accept": "text/event-stream",
         "Content-Type": "application/json",
-        "Connection": "keep-alive"
+        "Connection": "keep-alive",
     }
-    
+
     try:
-        response = requests.post(api_url, headers=headers, json=payload, timeout=60, stream=True)
+        response = requests.post(
+            api_url, headers=headers, json=payload, timeout=60, stream=True
+        )
         response.raise_for_status()  # Raise stored HTTPError, if one occurred
 
     except requests.exceptions.HTTPError as httpErr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,12 @@ packages = [{include = "fastapi_async_langchain"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = "^0.95.1"
-langchain = ">=0.0.166"
+langchain = ">=0.0.167"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^3.3.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,6 @@ langchain = ">=0.0.166"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^3.3.1"
-ruff = "^0.0.265"
-black = "^23.3.0"
-isort = "^5.12.0"
-prettier = "^0.0.7"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,12 @@ packages = [{include = "fastapi_async_langchain"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = "^0.95.1"
-langchain = ">=0.0.166"
+langchain = "~0.0.164"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^3.3.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,16 @@ packages = [{include = "fastapi_async_langchain"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = "^0.95.1"
-langchain = "~0.0.164"
+langchain = ">=0.0.166"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.3.1"
+ruff = "^0.0.265"
+black = "^23.3.0"
+isort = "^5.12.0"
+prettier = "^0.0.7"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Changed the Gradio query function to include keep-alive, catch various errors and specify a smaller chunk_size.

In the previous version, streaming content via Gradio always "stalled" for me and was interrupted (in contrast to the web-socket pure FastAPI version).

With this fix I didn't see any interruptions with the gradio version anymore and the complete answer is always streamed.

(I also added seperate dev dependencies from the pre-commits to the pyproject.toml file, feel free to remove this part if you don't want it for whatever reason).